### PR TITLE
fix: Tell the user when the contract has not been deployed.

### DIFF
--- a/src/contract/address.js
+++ b/src/contract/address.js
@@ -1,3 +1,10 @@
 // sync-ed from root via `tr sync-refs`
-import config from "../refs.terrain.json"
-export const contractAdress = (wallet) => config[wallet.network.name].counter.contractAddresses.default
+import config from "../refs.terrain.json";
+export const contractAdress = (wallet) => {
+  // Make sure the contract has actually been deployed.
+  if (config[wallet.network.name]?.counter?.contractAddresses?.default) {
+    return config[wallet.network.name]?.counter?.contractAddresses?.default;
+  }
+
+  alert(`Contract not deployed on currently selected network: ${wallet.network.name}\n\nSelect the correct network in your wallet!`);
+}


### PR DESCRIPTION
https://user-images.githubusercontent.com/142006/162771063-ee48666a-4758-4999-b0c6-31c05ab11517.mov

Pretty often a new developer will forget to switch to LocalTerra or testnet in Terra station and encounter a fatal error locking up the frontend. This PR will alert the user that the contract was not found on the selected network. 